### PR TITLE
Bump struts2-core from 2.3.4.1 to 2.3.34 in /BookStoreManager

### DIFF
--- a/BookStoreManager/pom.xml
+++ b/BookStoreManager/pom.xml
@@ -115,7 +115,7 @@
 		<dependency>
 			<groupId>org.apache.struts</groupId>
 			<artifactId>struts2-core</artifactId>
-			<version>2.3.4.1</version>
+			<version>2.3.34</version>
 			<!-- 在引入hibernate的时候放开这个,防止jar包冲突 -->
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
Bumps struts2-core from 2.3.4.1 to 2.3.34.

Signed-off-by: dependabot[bot] <support@github.com>